### PR TITLE
Inject ServiceMatcher's PathMatcher by name

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
@@ -76,9 +76,9 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 		}
 
 		@Bean
-		public ServiceMatcher serviceMatcher(PathMatcher pathMatcher) {
+		public ServiceMatcher serviceMatcher() {
 			ServiceMatcher serviceMatcher = new ServiceMatcher();
-			serviceMatcher.setMatcher(pathMatcher);
+			serviceMatcher.setMatcher(busPathMatcher());
 			return serviceMatcher;
 		}
 


### PR DESCRIPTION
Wiring a PathMatcher by type in the BusAutoConfiguration causes issues when other PathMatchers are also defined, e.g. WebMvcConfigurationSupport's mvcPathMatcher.

I ran into this when trying the samples from https://github.com/spring-cloud-samples/customers-stores.
I'm assuming that the intent here is to wire the busPathMatcher defined in the same Configuration class, so I now refer to that bean explicitly rather than relying on autowiring in the Bean method.