### PR TITLE
remove duplicated dependencies in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,16 +112,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-starter-bus-redis</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-starter-bus-kafka</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-bus</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
The dependencies (spring-cloud-starter-bus-redis and spring-cloud-starter-bus-kafka) have been declared twice. 