### PR TITLE
Use @StreamListener for message conversion

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.cloud.context.scope.refresh.RefreshScope;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.Output;
+import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
 import org.springframework.context.ApplicationContext;
@@ -32,7 +33,6 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
-import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.AntPathMatcher;
@@ -105,7 +105,7 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 		}
 	}
 
-	@ServiceActivator(inputChannel = SpringCloudBusClient.INPUT)
+	@StreamListener(SpringCloudBusClient.INPUT)
 	public void acceptRemote(RemoteApplicationEvent event) {
 		if (event instanceof AckRemoteApplicationEvent) {
 			if (this.bus.getTrace().isEnabled() && !this.serviceMatcher.isFromSelf(event)

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusEnvironmentPostProcessor.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusEnvironmentPostProcessor.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
-import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
@@ -46,10 +45,6 @@ public class BusEnvironmentPostProcessor implements EnvironmentPostProcessor {
 				+ ".content-type",
 				environment.getProperty("spring.cloud.bus.content-type",
 						"application/json"));
-		map.put("spring.cloud.stream.bindings." + SpringCloudBusClient.INPUT
-				+ ".content-type",
-				"application/x-java-object;type="
-						+ RemoteApplicationEvent.class.getName());
 		addOrReplace(environment.getPropertySources(), map);
 	}
 


### PR DESCRIPTION
- Remove the need for explicitly configuring the target class as the input content type

The intent is to de-emphasize the use of input content type in SCSt in favour of @StreamListener-based
conversion.