### PR TITLE
Upgrade to Spring Cloud Stream 1.1

### DIFF
--- a/spring-cloud-bus-dependencies/pom.xml
+++ b/spring-cloud-bus-dependencies/pom.xml
@@ -15,7 +15,7 @@
 	<description>Spring Cloud Bus Dependencies</description>
 	<properties>
 		<spring-cloud-commons.version>1.1.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
-        <spring-cloud-stream.version>1.0.1.BUILD-SNAPSHOT</spring-cloud-stream.version>
+        <spring-cloud-stream.version>Brooklyn.BUILD-SNAPSHOT</spring-cloud-stream.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
- use Brooklyn release train dependency
- remove dependency on defunct `AbstractFromMessageConverter`

(may require bumping up Spring Cloud Bus to 1.2 since this is a major dependency upgrade)