### PR TITLE
Fix bug: ObjectMapper should not register modules twice

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/jackson/BusJacksonAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/jackson/BusJacksonAutoConfiguration.java
@@ -38,14 +38,15 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 public class BusJacksonAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(name="busJsonConverter")
+	@ConditionalOnMissingBean(name = "busJsonConverter")
 	public BusJacksonMessageConverter busJsonConverter() {
 		return new BusJacksonMessageConverter();
 	}
 
 }
 
-class BusJacksonMessageConverter extends AbstractMessageConverter implements InitializingBean {
+class BusJacksonMessageConverter extends AbstractMessageConverter
+		implements InitializingBean {
 
 	private static final String DEFAULT_PACKAGE = ClassUtils
 			.getPackageName(RemoteApplicationEvent.class);
@@ -64,22 +65,23 @@ class BusJacksonMessageConverter extends AbstractMessageConverter implements Ini
 
 	public BusJacksonMessageConverter() {
 		super(MimeTypeUtils.APPLICATION_JSON);
-		this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-		this.mapper.registerModule(new SubtypeModule(findSubTypes()));
 	}
 
 	private Class<?>[] findSubTypes() {
 		List<Class<?>> types = new ArrayList<>();
 		if (this.packagesToScan != null) {
 			for (String pkg : this.packagesToScan) {
-				ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
-				provider.addIncludeFilter(new AssignableTypeFilter(RemoteApplicationEvent.class));
+				ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(
+						false);
+				provider.addIncludeFilter(
+						new AssignableTypeFilter(RemoteApplicationEvent.class));
 
 				Set<BeanDefinition> components = provider.findCandidateComponents(pkg);
 				for (BeanDefinition component : components) {
 					try {
 						types.add(Class.forName(component.getBeanClassName()));
-					} catch (ClassNotFoundException e) {
+					}
+					catch (ClassNotFoundException e) {
 						throw new IllegalStateException(
 								"Failed to scan classpath for remote event classes", e);
 					}

--- a/spring-cloud-bus/src/test/java/foo/bar/FooBarTestRemoteApplicationEvent.java
+++ b/spring-cloud-bus/src/test/java/foo/bar/FooBarTestRemoteApplicationEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foo.bar;
+
+import org.springframework.cloud.bus.event.RemoteApplicationEvent;
+
+@SuppressWarnings("serial")
+public class FooBarTestRemoteApplicationEvent extends RemoteApplicationEvent {
+	@SuppressWarnings("unused")
+	private FooBarTestRemoteApplicationEvent() {
+	}
+
+	protected FooBarTestRemoteApplicationEvent(final Object source,
+			final String originService, final String destinationService) {
+		super(source, originService, destinationService);
+	}
+
+	protected FooBarTestRemoteApplicationEvent(final Object source,
+			final String originService) {
+		super(source, originService);
+	}
+}

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/RemoteApplicationEventScanTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/RemoteApplicationEventScanTests.java
@@ -1,85 +1,140 @@
 package org.springframework.cloud.bus.jackson;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 import org.junit.Test;
 import org.springframework.boot.Banner;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.bus.event.AckRemoteApplicationEvent;
+import org.springframework.cloud.bus.event.EnvironmentChangeRemoteApplicationEvent;
+import org.springframework.cloud.bus.event.RefreshRemoteApplicationEvent;
 import org.springframework.cloud.bus.event.test.TestRemoteApplicationEvent;
+import org.springframework.cloud.bus.event.test.TypedRemoteApplicationEvent;
+import org.springframework.cloud.bus.jackson.SubtypeModuleTests.AnotherRemoteApplicationEvent;
+import org.springframework.cloud.bus.jackson.SubtypeModuleTests.MyRemoteApplicationEvent;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+
+import foo.bar.FooBarTestRemoteApplicationEvent;
+
 public class RemoteApplicationEventScanTests {
 
-    private BusJacksonMessageConverter converter;
+	private BusJacksonMessageConverter converter;
 
-    @Test
-    public void importingClassMetadataPackageRegistered() {
-        converter = createTestContext(DefaultConfig.class)
-                .getBean(BusJacksonMessageConverter.class);
+	@Test
+	public void importingClassMetadataPackageRegistered() {
+		converter = createTestContext(DefaultConfig.class)
+				.getBean(BusJacksonMessageConverter.class);
 
-        assertArrayEquals("RemoteApplicationEvent packages not registered",
-                (String[]) ReflectionTestUtils.getField(converter, "packagesToScan"),
-                new String[]{"org.springframework.cloud.bus.jackson",
-                        "org.springframework.cloud.bus.event"});
-    }
+		assertConverterBeanAfterPropertiesSet(
+				new String[] { "org.springframework.cloud.bus.jackson",
+						"org.springframework.cloud.bus.event" },
+				AnotherRemoteApplicationEvent.class, MyRemoteApplicationEvent.class,
+				TestRemoteApplicationEvent.class, TypedRemoteApplicationEvent.class);
+	}
 
-    @Test
-    public void annotationValuePackagesRegistered() {
-        converter = createTestContext(ValueConfig.class)
-                .getBean(BusJacksonMessageConverter.class);
+	@Test
+	public void annotationValuePackagesRegistered() {
+		converter = createTestContext(ValueConfig.class)
+				.getBean(BusJacksonMessageConverter.class);
 
-        assertArrayEquals("RemoteApplicationEvent packages not registered",
-                (String[]) ReflectionTestUtils.getField(converter, "packagesToScan"),
-                new String[]{"foo.bar", "com.acme", "org.springframework.cloud.bus.event"});
-    }
+		assertConverterBeanAfterPropertiesSet(
+				new String[] { "foo.bar", "com.acme",
+						"org.springframework.cloud.bus.event" },
+				FooBarTestRemoteApplicationEvent.class, TestRemoteApplicationEvent.class,
+				TypedRemoteApplicationEvent.class);
+	}
 
-    @Test
-    public void annotationValueBasePackagesRegistered() {
-        converter = createTestContext(BasePackagesConfig.class)
-                .getBean(BusJacksonMessageConverter.class);
+	@Test
+	public void annotationValueBasePackagesRegistered() {
+		converter = createTestContext(BasePackagesConfig.class)
+				.getBean(BusJacksonMessageConverter.class);
 
-        assertArrayEquals("RemoteApplicationEvent packages not registered",
-                (String[]) ReflectionTestUtils.getField(converter, "packagesToScan"),
-                new String[]{"foo.bar", "fizz.buzz", "com.acme", "org.springframework.cloud.bus.event"});
-    }
+		assertConverterBeanAfterPropertiesSet(
+				new String[] { "foo.bar", "fizz.buzz", "com.acme",
+						"org.springframework.cloud.bus.event" },
+				FooBarTestRemoteApplicationEvent.class, TestRemoteApplicationEvent.class,
+				TypedRemoteApplicationEvent.class);
+	}
 
-    @Test
-    public void annotationBasePackagesRegistered() {
-        converter = createTestContext(BasePackageClassesConfig.class)
-                .getBean(BusJacksonMessageConverter.class);
+	@Test
+	public void annotationBasePackagesRegistered() {
+		converter = createTestContext(BasePackageClassesConfig.class)
+				.getBean(BusJacksonMessageConverter.class);
 
-        assertArrayEquals("RemoteApplicationEvent packages not registered",
-                (String[]) ReflectionTestUtils.getField(converter, "packagesToScan"),
-                new String[]{"org.springframework.cloud.bus.event.test",
-                        "org.springframework.cloud.bus.event"});
-    }
+		assertConverterBeanAfterPropertiesSet(
+				new String[] { "org.springframework.cloud.bus.event.test",
+						"org.springframework.cloud.bus.event" },
+				TestRemoteApplicationEvent.class, TypedRemoteApplicationEvent.class);
+	}
 
-    private ConfigurableApplicationContext createTestContext(Class<?> configuration) {
-        return new SpringApplicationBuilder(configuration)
-                .web(false)
-                .bannerMode(Banner.Mode.OFF)
-                .run();
-    }
+	private ConfigurableApplicationContext createTestContext(
+			final Class<?> configuration) {
+		return new SpringApplicationBuilder(configuration).web(false)
+				.bannerMode(Banner.Mode.OFF).run();
+	}
 
-    @Configuration
-    @RemoteApplicationEventScan
-    static class DefaultConfig {
-    }
+	private void assertConverterBeanAfterPropertiesSet(
+			final String[] expectedPackageToScan,
+			final Class<?>... expectedRegisterdClasses) {
+		final ObjectMapper mapper = (ObjectMapper) ReflectionTestUtils.getField(converter,
+				"mapper");
 
-    @Configuration
-    @RemoteApplicationEventScan({"com.acme", "foo.bar"})
-    static class ValueConfig {
-    }
+		@SuppressWarnings("unchecked")
+		final LinkedHashSet<NamedType> registeredSubtypes = (LinkedHashSet<NamedType>) ReflectionTestUtils
+				.getField(mapper.getSubtypeResolver(), "_registeredSubtypes");
 
-    @Configuration
-    @RemoteApplicationEventScan(basePackages = {"com.acme", "foo.bar", "fizz.buzz"})
-    static class BasePackagesConfig {
-    }
+		final List<Class<?>> expectedRegisterdClassesAsList = new ArrayList<Class<?>>(
+				Arrays.asList(expectedRegisterdClasses));
+		addStandardSpringCloudEventBusEvents(expectedRegisterdClassesAsList);
 
-    @Configuration
-    @RemoteApplicationEventScan(basePackageClasses = TestRemoteApplicationEvent.class)
-    static class BasePackageClassesConfig {
-    }
+		assertTrue("Wrong RemoteApplicationEvent classes are registerd in object mapper",
+				expectedRegisterdClassesAsList.size() == registeredSubtypes.size());
+
+		for (final NamedType namedType : registeredSubtypes) {
+			assertTrue(expectedRegisterdClassesAsList.contains(namedType.getType()));
+		}
+
+		assertArrayEquals("RemoteApplicationEvent packages not registered",
+				(String[]) ReflectionTestUtils.getField(converter, "packagesToScan"),
+				expectedPackageToScan);
+
+	}
+
+	private void addStandardSpringCloudEventBusEvents(
+			final List<Class<?>> expectedRegisterdClassesAsList) {
+		expectedRegisterdClassesAsList.add(AckRemoteApplicationEvent.class);
+		expectedRegisterdClassesAsList.add(EnvironmentChangeRemoteApplicationEvent.class);
+		expectedRegisterdClassesAsList.add(RefreshRemoteApplicationEvent.class);
+	}
+
+	@Configuration
+	@RemoteApplicationEventScan
+	static class DefaultConfig {
+	}
+
+	@Configuration
+	@RemoteApplicationEventScan({ "com.acme", "foo.bar" })
+	static class ValueConfig {
+	}
+
+	@Configuration
+	@RemoteApplicationEventScan(basePackages = { "com.acme", "foo.bar", "fizz.buzz" })
+	static class BasePackagesConfig {
+	}
+
+	@Configuration
+	@RemoteApplicationEventScan(basePackageClasses = TestRemoteApplicationEvent.class)
+	static class BasePackageClassesConfig {
+	}
 }


### PR DESCRIPTION
Fix bug: ObjectMapper should not register modules twice and adapt unit test cases

Signed-off-by: SirWayne <melzer.dennis@gmail.com>