### PR TITLE
Refine handling of wildcards

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/RemoteApplicationEvent.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/RemoteApplicationEvent.java
@@ -30,12 +30,16 @@ public abstract class RemoteApplicationEvent extends ApplicationEvent {
 		super(source);
 		this.originService = originService;
 		if (destinationService == null) {
-			destinationService = "*";
+			destinationService = "**";
 		}
-		if (StringUtils.countOccurrencesOf(destinationService, ":") <= 1
-				&& !destinationService.contains("*")) {
-			// All instances of the destination unless specifically requested
-			destinationService = destinationService + ":**";
+		// If the destinationService is not already a wildcard, match everything that follows
+		// if there at most two path elements, and last element is not a global wildcard already
+		if (!"**".equals(destinationService)) {
+			if (StringUtils.countOccurrencesOf(destinationService, ":") <= 1
+					&& !StringUtils.endsWithIgnoreCase(destinationService, ":**")) {
+				// All instances of the destination unless specifically requested
+				destinationService = destinationService + ":**";
+			}
 		}
 		this.destinationService = destinationService;
 		this.id = UUID.randomUUID().toString();

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherTests.java
@@ -72,6 +72,51 @@ public class ServiceMatcherTests {
 	}
 
 	@Test
+	public void forSelfWithGlobalWildcard() {
+		assertThat(
+				matcher.isForSelf(
+						new EnvironmentChangeRemoteApplicationEvent(this, "foo:bar:spam",
+								"**", Collections.<String, String>emptyMap())),
+				is(true));
+	}
+
+	@Test
+	public void forSelfWithWildcardName() {
+		assertThat(
+				matcher.isForSelf(
+						new EnvironmentChangeRemoteApplicationEvent(this, "foo:bar:spam",
+								"o*", Collections.<String, String>emptyMap())),
+				is(true));
+	}
+
+	@Test
+	public void forSelfWithWildcardNameAndProfile() {
+		assertThat(
+				matcher.isForSelf(
+						new EnvironmentChangeRemoteApplicationEvent(this, "foo:bar:spam",
+								"o*:t*", Collections.<String, String>emptyMap())),
+				is(true));
+	}
+
+	@Test
+	public void forSelfWithWildcardString() {
+		assertThat(
+				matcher.isForSelf(
+						new EnvironmentChangeRemoteApplicationEvent(this, "foo:bar:spam",
+								"o*", Collections.<String, String>emptyMap())),
+				is(true));
+	}
+
+	@Test
+	public void notForSelfWithWildCardNameAndMismatchingProfile() {
+		assertThat(
+				matcher.isForSelf(
+						new EnvironmentChangeRemoteApplicationEvent(this, "foo:bar:spam",
+								"o*:f*", Collections.<String, String>emptyMap())),
+				is(false));
+	}
+
+	@Test
 	public void forSelfWithDoubleWildcard() {
 		assertThat(
 				matcher.isForSelf(


### PR DESCRIPTION
Fixes #43

- Use a global wildcard if `destinationService` is null;
- Append `:**` if the destinationService is not a global wildcard already,
  it is in the form `foo` or `foo:bar` and does not end in a global wildcard