### PR TITLE
UnknownRemoteApplicationEvent if deserialization fails

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/UnknownRemoteApplicationEvent.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/UnknownRemoteApplicationEvent.java
@@ -1,0 +1,36 @@
+package org.springframework.cloud.bus.event;
+
+/**
+ *
+ * @author Stefan Pfeiffer
+ */
+public class UnknownRemoteApplicationEvent extends RemoteApplicationEvent {
+
+  protected String typeInfo;
+  protected byte[] payload;
+
+  @SuppressWarnings("unused")
+  private UnknownRemoteApplicationEvent() {
+    super();
+    this.typeInfo = null;
+    this.payload = null;
+  }
+
+  public UnknownRemoteApplicationEvent(Object source, String typeInfo, byte[] payload) {
+    super(source, null, null);
+    this.typeInfo = typeInfo;
+    this.payload = payload;
+  }
+
+  public String getTypeInfo() {
+    return this.typeInfo;
+  }
+
+  public byte[] getPayload() {
+    return this.payload;
+  }
+
+  public String getPayloadAsString() {
+    return new String(this.payload);
+  }
+}

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/UnknownRemoteApplicationEvent.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/UnknownRemoteApplicationEvent.java
@@ -6,31 +6,31 @@ package org.springframework.cloud.bus.event;
  */
 public class UnknownRemoteApplicationEvent extends RemoteApplicationEvent {
 
-  protected String typeInfo;
-  protected byte[] payload;
+	protected String typeInfo;
+	protected byte[] payload;
 
-  @SuppressWarnings("unused")
-  private UnknownRemoteApplicationEvent() {
-    super();
-    this.typeInfo = null;
-    this.payload = null;
-  }
+	@SuppressWarnings("unused")
+	private UnknownRemoteApplicationEvent() {
+		super();
+		this.typeInfo = null;
+		this.payload = null;
+	}
 
-  public UnknownRemoteApplicationEvent(Object source, String typeInfo, byte[] payload) {
-    super(source, null, null);
-    this.typeInfo = typeInfo;
-    this.payload = payload;
-  }
+	public UnknownRemoteApplicationEvent(Object source, String typeInfo, byte[] payload) {
+		super(source, null, null);
+		this.typeInfo = typeInfo;
+		this.payload = payload;
+	}
 
-  public String getTypeInfo() {
-    return this.typeInfo;
-  }
+	public String getTypeInfo() {
+		return this.typeInfo;
+	}
 
-  public byte[] getPayload() {
-    return this.payload;
-  }
+	public byte[] getPayload() {
+		return this.payload;
+	}
 
-  public String getPayloadAsString() {
-    return new String(this.payload);
-  }
+	public String getPayloadAsString() {
+		return new String(this.payload);
+	}
 }

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/jackson/BusJacksonAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/jackson/BusJacksonAutoConfiguration.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
  * @author Spencer Gibb
  * @author Dave Syer
  * @author Donovan Muller
+ * @author Stefan Pfeiffer
  */
 @Configuration
 @ConditionalOnBusEnabled
@@ -107,7 +108,7 @@ class BusJacksonMessageConverter extends AbstractMessageConverter
 			Object payload = message.getPayload();
 
 			if (payload instanceof byte[]) {
-			  try {
+				try {
 					result = this.mapper.readValue((byte[]) payload, targetClass);
 				} catch (InvalidTypeIdException e) {
 					return new UnknownRemoteApplicationEvent(new Object(), e.getTypeId(), (byte[]) payload);

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/RemoteApplicationEventScanTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/RemoteApplicationEventScanTests.java
@@ -11,6 +11,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.bus.event.AckRemoteApplicationEvent;
 import org.springframework.cloud.bus.event.EnvironmentChangeRemoteApplicationEvent;
 import org.springframework.cloud.bus.event.RefreshRemoteApplicationEvent;
+import org.springframework.cloud.bus.event.UnknownRemoteApplicationEvent;
 import org.springframework.cloud.bus.event.test.TestRemoteApplicationEvent;
 import org.springframework.cloud.bus.event.test.TypedRemoteApplicationEvent;
 import org.springframework.cloud.bus.jackson.SubtypeModuleTests.AnotherRemoteApplicationEvent;
@@ -116,6 +117,7 @@ public class RemoteApplicationEventScanTests {
 		expectedRegisterdClassesAsList.add(AckRemoteApplicationEvent.class);
 		expectedRegisterdClassesAsList.add(EnvironmentChangeRemoteApplicationEvent.class);
 		expectedRegisterdClassesAsList.add(RefreshRemoteApplicationEvent.class);
+		expectedRegisterdClassesAsList.add(UnknownRemoteApplicationEvent.class);
 	}
 
 	@Configuration

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/SubtypeModuleTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/SubtypeModuleTests.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
+import org.springframework.cloud.bus.event.UnknownRemoteApplicationEvent;
 import org.springframework.cloud.bus.event.test.TestRemoteApplicationEvent;
 import org.springframework.cloud.bus.event.test.TypedRemoteApplicationEvent;
 import org.springframework.messaging.support.MessageBuilder;
@@ -49,6 +50,18 @@ public class SubtypeModuleTests {
 				MessageBuilder.withPayload("{\"type\":\"TestRemoteApplicationEvent\"}").build(),
 				RemoteApplicationEvent.class);
 		assertTrue("event is wrong type", event instanceof TestRemoteApplicationEvent);
+	}
+
+	@Test
+	public void testDeserializeUnknownTypeWithMessageConverter() throws Exception {
+		BusJacksonMessageConverter converter = new BusJacksonAutoConfiguration().busJsonConverter();
+		converter.afterPropertiesSet();
+		Object event = converter.fromMessage(
+				MessageBuilder.withPayload("{\"type\":\"NotDefinedTestRemoteApplicationEvent\"}").build(),
+				RemoteApplicationEvent.class);
+		assertTrue("event is wrong type", event instanceof UnknownRemoteApplicationEvent);
+		assertEquals("type information is wrong", "NotDefinedTestRemoteApplicationEvent", ((UnknownRemoteApplicationEvent)event).getTypeInfo());
+		assertEquals("payload is wrong", "{\"type\":\"NotDefinedTestRemoteApplicationEvent\"}", ((UnknownRemoteApplicationEvent)event).getPayloadAsString());
 	}
 
 	@Test

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/SubtypeModuleTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/SubtypeModuleTests.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Spencer Gibb
+ * @author Stefan Pfeiffer
  */
 public class SubtypeModuleTests {
 


### PR DESCRIPTION
Fixes #48.

If the Jackson deserializer cannot deserialize the event payload received,
it emits an UnknownRemoteApplicationEvent that wraps the type information
expected and the raw payload. Client applications can register on events
of type UnknownRemoteApplicationEvent and handle these cases
appropriately.