### PR TITLE
When we got an UnknownRemoteApplicationEvent, ignore it.

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
@@ -30,12 +30,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.bus.endpoint.BusEndpoint;
 import org.springframework.cloud.bus.endpoint.EnvironmentBusEndpoint;
 import org.springframework.cloud.bus.endpoint.RefreshBusEndpoint;
-import org.springframework.cloud.bus.event.AckRemoteApplicationEvent;
-import org.springframework.cloud.bus.event.EnvironmentChangeListener;
-import org.springframework.cloud.bus.event.RefreshListener;
-import org.springframework.cloud.bus.event.RemoteApplicationEvent;
-import org.springframework.cloud.bus.event.SentApplicationEvent;
-import org.springframework.cloud.bus.event.TraceListener;
+import org.springframework.cloud.bus.event.*;
 import org.springframework.cloud.context.environment.EnvironmentManager;
 import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.cloud.context.scope.refresh.RefreshScope;
@@ -124,6 +119,10 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 
 	@StreamListener(SpringCloudBusClient.INPUT)
 	public void acceptRemote(RemoteApplicationEvent event) {
+		if (event instanceof UnknownRemoteApplicationEvent) {
+			// We can't process this event.
+			return;
+		}
 		if (event instanceof AckRemoteApplicationEvent) {
 			if (this.bus.getTrace().isEnabled() && !this.serviceMatcher.isFromSelf(event)
 					&& this.applicationEventPublisher != null) {


### PR DESCRIPTION
When spring cloud bus got an event which is not registered with @RemoteApplicationEventScan,
spring cloud bus get it as UnknownRemoteApplicationEvent class instance.
But, that instance has no originService, destinationService,
it can't be processed in BusAutoConfiguration.acceptRemote().
So it should be ignored.