### PR TITLE
Respect spring.cloud.config.name value in ServiceMatcher

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
@@ -20,6 +20,7 @@ package org.springframework.cloud.bus;
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.trace.http.HttpTraceRepository;
@@ -182,8 +183,8 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 
 		@Bean
 		public ServiceMatcher serviceMatcher(@BusPathMatcher PathMatcher pathMatcher,
-				BusProperties properties) {
-			ServiceMatcher serviceMatcher = new ServiceMatcher(pathMatcher, properties.getId());
+				BusProperties properties, @Value("${spring.cloud.config.name:}") String[] configNames) {
+			ServiceMatcher serviceMatcher = new ServiceMatcher(pathMatcher, properties.getId(), configNames);
 			return serviceMatcher;
 		}
 

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
@@ -69,11 +69,8 @@ import org.springframework.util.PathMatcher;
 @ConditionalOnBusEnabled
 @EnableBinding(SpringCloudBusClient.class)
 @EnableConfigurationProperties(BusProperties.class)
-@AutoConfigureBefore(BindingServiceConfiguration.class) // so stream bindings work
-														// properly
-@AutoConfigureAfter(LifecycleMvcEndpointAutoConfiguration.class) // so actuator endpoints
-																	// have needed
-																	// dependencies
+@AutoConfigureBefore(BindingServiceConfiguration.class) // so stream bindings work properly
+@AutoConfigureAfter(LifecycleMvcEndpointAutoConfiguration.class) // so actuator endpoints have needed dependencies
 public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 
 	public static final String BUS_PATH_MATCHER_NAME = "busPathMatcher";
@@ -90,8 +87,7 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 
 	private final BusProperties bus;
 
-	public BusAutoConfiguration(ServiceMatcher serviceMatcher,
-			BindingServiceProperties bindings, BusProperties bus) {
+	public BusAutoConfiguration(ServiceMatcher serviceMatcher, BindingServiceProperties bindings, BusProperties bus) {
 		this.serviceMatcher = serviceMatcher;
 		this.bindings = bindings;
 		this.bus = bus;
@@ -107,8 +103,7 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 		}
 		BindingProperties input = this.bindings.getBindings()
 				.get(SpringCloudBusClient.INPUT);
-		if (input.getDestination() == null
-				|| input.getDestination().equals(SpringCloudBusClient.INPUT)) {
+		if (input.getDestination() == null || input.getDestination().equals(SpringCloudBusClient.INPUT)) {
 			input.setDestination(this.bus.getDestination());
 		}
 		BindingProperties outputBinding = this.bindings.getBindings()
@@ -119,8 +114,7 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 		}
 		BindingProperties output = this.bindings.getBindings()
 				.get(SpringCloudBusClient.OUTPUT);
-		if (output.getDestination() == null
-				|| output.getDestination().equals(SpringCloudBusClient.OUTPUT)) {
+		if (output.getDestination() == null || output.getDestination().equals(SpringCloudBusClient.OUTPUT)) {
 			output.setDestination(this.bus.getDestination());
 		}
 	}

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherWithConfigNamesTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherWithConfigNamesTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.bus;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.cloud.bus.event.EnvironmentChangeRemoteApplicationEvent;
+import org.springframework.util.AntPathMatcher;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Stefan Pfeiffer
+ *
+ */
+public class ServiceMatcherWithConfigNamesTests {
+
+	private static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
+
+	private ServiceMatcher matcher;
+
+	@Before
+	public void init() {
+		initMatcher("otherid:two:8888", new String[] {"one", "three"});
+	}
+
+	private void initMatcher(String id, String[] configNames) {
+		BusProperties properties = new BusProperties();
+		properties.setId(id);
+		DefaultBusPathMatcher pathMatcher = new DefaultBusPathMatcher(new AntPathMatcher(":"));
+		matcher = new ServiceMatcher(pathMatcher, properties.getId(), configNames);
+	}
+
+	@Test
+	public void forSelfWithWildcard() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "one:two:*", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void forSelfWithWildcardAndOtherConfigName() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "three:two:*", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void forSelfWithGlobalWildcard() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "**", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void forSelfWithWildcardName() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "o*", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void forSelfWithWildcardNameAndProfile() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "o*:t*", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void forSelfWithWildcardString() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "o*", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void notForSelfWithWildCardNameAndMismatchingProfile() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "o*:f*", EMPTY_MAP)), is(false));
+	}
+
+	@Test
+	public void forSelfWithDoubleWildcard() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "one:**", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void forSelfWithNoWildcard() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "one", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void forSelfWithProfileNoWildcard() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "one:two", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void notForSelf() {
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "one:two:9999", EMPTY_MAP)), is(false));
+	}
+
+	@Test
+	public void forSelfWithMultipleProfiles() {
+		initMatcher("customerportal:dev,cloud:80", new String[] {"one", "three"});
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "one:cloud:*", EMPTY_MAP)), is(true));
+	}
+
+	@Test
+	public void notForSelfWithMultipleProfiles() {
+		initMatcher("customerportal:dev,cloud:80", new String[] {"one", "three"});
+		assertThat(matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+				"foo:bar:spam", "bar:cloud:*", EMPTY_MAP)), is(false));
+	}
+
+	@Test
+	public void notForSelfWithMultipleProfilesDifferentPort() {
+		initMatcher("customerportal:dev,cloud:80", new String[] {"one", "three"});
+		assertThat(
+				matcher.isForSelf(new EnvironmentChangeRemoteApplicationEvent(this,
+						"foo:bar:spam", "customerportal:cloud:8008", EMPTY_MAP)),
+				is(false));
+	}
+
+}


### PR DESCRIPTION
To get notified about changes in properties/yml files that are not named after the service name but
still get pulled from the config server, the value of spring.cloud.config.name is now honored in
addition to the service id when matching destination service ids of incoming RemoteRefreshEvents.

Fixes GH-132