### PR TITLE
URL Cleanup

### DIFF
--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 3 occurrences
* http://www.w3.org/1999/xlink with 3 occurrences
* http://www.w3.org/2000/svg with 1 occurrences