### PR TITLE
Reworked RemoteApplicationRegistrar

### DIFF
--- a/spring-cloud-bus/.flattened-pom.xml
+++ b/spring-cloud-bus/.flattened-pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/spring-cloud-bus/.flattened-pom.xml
+++ b/spring-cloud-bus/.flattened-pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/RemoteApplicationEventScanTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/RemoteApplicationEventScanTests.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.bus.jackson.SubtypeModuleTests.AnotherRemoteApp
 import org.springframework.cloud.bus.jackson.SubtypeModuleTests.MyRemoteApplicationEvent;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -149,9 +150,15 @@ public class RemoteApplicationEventScanTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@RemoteApplicationEventScan(
-			basePackages = { "com.acme", "test.foo.bar", "fizz.buzz" })
+	@Import(ExtraBasePackagesConfig.class)
+	@RemoteApplicationEventScan(basePackages = { "com.acme", "test.foo.bar" })
 	static class BasePackagesConfig {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@RemoteApplicationEventScan(basePackages = { "fizz.buzz" })
+	static class ExtraBasePackagesConfig {
 
 	}
 


### PR DESCRIPTION
Hi,

Currently when your application has a configuration that has its own @RemoteApplicationEventsScan("somePackageA") annotation but also imports a configuration from elsewhere which has a @RemoteApplicationEventsScan("somePackageB") you will not get the desired result.
Only one of the two annotations will be handled successfully.  (The last one found)

This PR is to alter this behaviour so that the beanDefinition is no longer always overridden but the 'packages' to scan property is updated with a merged set.

The test has also been altered to represent this case.

