### PR TITLE
Pass BusProperties in order to get the most up to date bus id

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
@@ -194,8 +194,8 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 				BusProperties properties, Environment environment) {
 			String[] configNames = environment.getProperty(CLOUD_CONFIG_NAME_PROPERTY,
 					String[].class, new String[] {});
-			ServiceMatcher serviceMatcher = new ServiceMatcher(pathMatcher,
-					properties.getId(), configNames);
+			ServiceMatcher serviceMatcher = new ServiceMatcher(pathMatcher, properties,
+					configNames);
 			return serviceMatcher;
 		}
 
@@ -236,7 +236,7 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 			@ConditionalOnAvailableEndpoint
 			public EnvironmentBusEndpoint environmentBusEndpoint(
 					ApplicationContext context, BusProperties bus) {
-				return new EnvironmentBusEndpoint(context, bus.getId());
+				return new EnvironmentBusEndpoint(context, bus);
 			}
 
 		}

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusRefreshAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusRefreshAutoConfiguration.java
@@ -56,7 +56,7 @@ public class BusRefreshAutoConfiguration {
 		@ConditionalOnAvailableEndpoint
 		public RefreshBusEndpoint refreshBusEndpoint(ApplicationContext context,
 				BusProperties bus) {
-			return new RefreshBusEndpoint(context, bus.getId());
+			return new RefreshBusEndpoint(context, bus);
 		}
 
 	}

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/ServiceMatcher.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/ServiceMatcher.java
@@ -26,22 +26,23 @@ public class ServiceMatcher {
 
 	private final PathMatcher matcher;
 
-	private final String id;
+	private final BusProperties busProperties;
 
 	private String[] configNames = new String[] {};
 
-	public ServiceMatcher(PathMatcher matcher, String id) {
+	public ServiceMatcher(PathMatcher matcher, BusProperties busProperties) {
 		this.matcher = matcher;
-		this.id = id;
+		this.busProperties = busProperties;
 	}
 
-	public ServiceMatcher(PathMatcher matcher, String id, String[] configNames) {
-		this(matcher, id);
+	public ServiceMatcher(PathMatcher matcher, BusProperties busProperties,
+			String[] configNames) {
+		this(matcher, busProperties);
 
-		int colonIndex = id.indexOf(":");
+		int colonIndex = busProperties.getId().indexOf(":");
 		if (colonIndex >= 0) {
 			// if the id contains profiles and port, append them to the config names
-			String profilesAndPort = id.substring(colonIndex);
+			String profilesAndPort = busProperties.getId().substring(colonIndex);
 			for (int i = 0; i < configNames.length; i++) {
 				configNames[i] = configNames[i] + profilesAndPort;
 			}
@@ -73,7 +74,7 @@ public class ServiceMatcher {
 	}
 
 	public String getServiceId() {
-		return this.id;
+		return busProperties.getId();
 	}
 
 }

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/endpoint/AbstractBusEndpoint.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/endpoint/AbstractBusEndpoint.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.bus.endpoint;
 
+import org.springframework.cloud.bus.BusProperties;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -26,15 +27,16 @@ public class AbstractBusEndpoint {
 
 	private ApplicationEventPublisher context;
 
-	private String appId;
+	private BusProperties busProperties;
 
-	public AbstractBusEndpoint(ApplicationEventPublisher context, String appId) {
+	public AbstractBusEndpoint(ApplicationEventPublisher context,
+			BusProperties busProperties) {
 		this.context = context;
-		this.appId = appId;
+		this.busProperties = busProperties;
 	}
 
 	protected String getInstanceId() {
-		return this.appId;
+		return busProperties.getId();
 	}
 
 	protected void publish(ApplicationEvent event) {

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/endpoint/EnvironmentBusEndpoint.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/endpoint/EnvironmentBusEndpoint.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.cloud.bus.BusProperties;
 import org.springframework.cloud.bus.event.EnvironmentChangeRemoteApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -31,8 +32,9 @@ import org.springframework.context.ApplicationEventPublisher;
 @Endpoint(id = "bus-env") // TODO: document
 public class EnvironmentBusEndpoint extends AbstractBusEndpoint {
 
-	public EnvironmentBusEndpoint(ApplicationEventPublisher context, String id) {
-		super(context, id);
+	public EnvironmentBusEndpoint(ApplicationEventPublisher context,
+			BusProperties busProperties) {
+		super(context, busProperties);
 	}
 
 	@WriteOperation

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/endpoint/RefreshBusEndpoint.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/endpoint/RefreshBusEndpoint.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.bus.endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.cloud.bus.BusProperties;
 import org.springframework.cloud.bus.event.RefreshRemoteApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -28,8 +29,9 @@ import org.springframework.context.ApplicationEventPublisher;
 @Endpoint(id = "bus-refresh") // TODO: document new id
 public class RefreshBusEndpoint extends AbstractBusEndpoint {
 
-	public RefreshBusEndpoint(ApplicationEventPublisher context, String id) {
-		super(context, id);
+	public RefreshBusEndpoint(ApplicationEventPublisher context,
+			BusProperties busProperties) {
+		super(context, busProperties);
 	}
 
 	@WriteOperation

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherTests.java
@@ -47,7 +47,7 @@ public class ServiceMatcherTests {
 		properties.setId(id);
 		DefaultBusPathMatcher pathMatcher = new DefaultBusPathMatcher(
 				new AntPathMatcher(":"));
-		this.matcher = new ServiceMatcher(pathMatcher, properties.getId());
+		this.matcher = new ServiceMatcher(pathMatcher, properties);
 	}
 
 	@Test

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherWithConfigNamesTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/ServiceMatcherWithConfigNamesTests.java
@@ -47,7 +47,7 @@ public class ServiceMatcherWithConfigNamesTests {
 		properties.setId(id);
 		DefaultBusPathMatcher pathMatcher = new DefaultBusPathMatcher(
 				new AntPathMatcher(":"));
-		this.matcher = new ServiceMatcher(pathMatcher, properties.getId(), configNames);
+		this.matcher = new ServiceMatcher(pathMatcher, properties, configNames);
 	}
 
 	@Test

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/endpoint/RefreshBusEndpointTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/endpoint/RefreshBusEndpointTests.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.bus.endpoint;
 
 import org.junit.Test;
 
+import org.springframework.cloud.bus.BusProperties;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -27,7 +29,9 @@ public class RefreshBusEndpointTests {
 
 	@Test
 	public void instanceId() throws Exception {
-		RefreshBusEndpoint endpoint = new RefreshBusEndpoint(null, "foo");
+		BusProperties busProperties = new BusProperties();
+		busProperties.setId("foo");
+		RefreshBusEndpoint endpoint = new RefreshBusEndpoint(null, busProperties);
 		assertThat(endpoint.getInstanceId()).isEqualTo("foo");
 	}
 


### PR DESCRIPTION
The bus id could change, for example in the case of a refresh event.  When that happens beans that were passed the bus id may be out of sync if the `busid` property is not set because we use a random number.