### PR TITLE
Refresh Context Only If Event Targets App

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Bus Docs</name>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.1.BUILD-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Bus Docs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-bus-parent</artifactId>
-	<version>2.2.1.BUILD-SNAPSHOT</version>
+	<version>3.0.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>spring-cloud-bus-parent</name>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -28,8 +28,8 @@
 	</modules>
 
 	<properties>
-		<spring-cloud-commons.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-commons.version>
-		<spring-cloud-stream.version>Horsham.SR1</spring-cloud-stream.version>
+		<spring-cloud-commons.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<bintray.package>bus</bintray.package>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-bus-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>2.2.1.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>spring-cloud-bus-parent</name>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -28,8 +28,8 @@
 	</modules>
 
 	<properties>
-		<spring-cloud-commons.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
-		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
+		<spring-cloud-commons.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-stream.version>Horsham.SR1</spring-cloud-stream.version>
 		<bintray.package>bus</bintray.package>
 	</properties>
 

--- a/spring-cloud-bus-dependencies/pom.xml
+++ b/spring-cloud-bus-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.1.RELEASE</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-bus-dependencies</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>2.2.1.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-bus-dependencies</name>
 	<description>Spring Cloud Bus Dependencies</description>

--- a/spring-cloud-bus-dependencies/pom.xml
+++ b/spring-cloud-bus-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.2.1.RELEASE</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-bus-dependencies</artifactId>
-	<version>2.2.1.BUILD-SNAPSHOT</version>
+	<version>3.0.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-bus-dependencies</name>
 	<description>Spring Cloud Bus Dependencies</description>

--- a/spring-cloud-bus-tests/pom.xml
+++ b/spring-cloud-bus-tests/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 

--- a/spring-cloud-bus-tests/pom.xml
+++ b/spring-cloud-bus-tests/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.1.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 

--- a/spring-cloud-bus/pom.xml
+++ b/spring-cloud-bus/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 

--- a/spring-cloud-bus/pom.xml
+++ b/spring-cloud-bus/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.1.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusAutoConfiguration.java
@@ -49,11 +49,8 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
-import org.springframework.core.env.Environment;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.util.AntPathMatcher;
-import org.springframework.util.PathMatcher;
 
 /**
  * @author Spencer Gibb
@@ -65,7 +62,8 @@ import org.springframework.util.PathMatcher;
 @EnableConfigurationProperties(BusProperties.class)
 @AutoConfigureBefore(BindingServiceConfiguration.class)
 // so stream bindings work properly
-@AutoConfigureAfter(LifecycleMvcEndpointAutoConfiguration.class)
+@AutoConfigureAfter({ LifecycleMvcEndpointAutoConfiguration.class,
+		ServiceMatcherAutoConfiguration.class })
 // so actuator endpoints have needed dependencies
 public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 
@@ -176,29 +174,6 @@ public class BusAutoConfiguration implements ApplicationEventPublisherAware {
 					event.getOriginService(), event.getDestinationService(),
 					event.getId(), event.getClass()));
 		}
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	protected static class MatcherConfiguration {
-
-		@BusPathMatcher
-		// There is a @Bean of type PathMatcher coming from Spring MVC
-		@ConditionalOnMissingBean(name = BusAutoConfiguration.BUS_PATH_MATCHER_NAME)
-		@Bean(name = BusAutoConfiguration.BUS_PATH_MATCHER_NAME)
-		public PathMatcher busPathMatcher() {
-			return new DefaultBusPathMatcher(new AntPathMatcher(":"));
-		}
-
-		@Bean
-		public ServiceMatcher serviceMatcher(@BusPathMatcher PathMatcher pathMatcher,
-				BusProperties properties, Environment environment) {
-			String[] configNames = environment.getProperty(CLOUD_CONFIG_NAME_PROPERTY,
-					String[].class, new String[] {});
-			ServiceMatcher serviceMatcher = new ServiceMatcher(pathMatcher,
-					properties.getId(), configNames);
-			return serviceMatcher;
-		}
-
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusRefreshAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/BusRefreshAutoConfiguration.java
@@ -41,12 +41,12 @@ public class BusRefreshAutoConfiguration {
 	@ConditionalOnProperty(value = "spring.cloud.bus.refresh.enabled",
 			matchIfMissing = true)
 	@ConditionalOnBean(ContextRefresher.class)
-	public RefreshListener refreshListener(ContextRefresher contextRefresher) {
-		return new RefreshListener(contextRefresher);
+	public RefreshListener refreshListener(ContextRefresher contextRefresher,
+			ServiceMatcher serviceMatcher) {
+		return new RefreshListener(contextRefresher, serviceMatcher);
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnBean(ContextRefresher.class)
 	@ConditionalOnClass(
 			name = { "org.springframework.boot.actuate.endpoint.annotation.Endpoint",
 					"org.springframework.cloud.context.scope.refresh.RefreshScope" })

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/ServiceMatcherAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/ServiceMatcherAutoConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.bus;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import static org.springframework.cloud.bus.BusAutoConfiguration.CLOUD_CONFIG_NAME_PROPERTY;
+
+/**
+ * @author Ryan Baxter
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnBusEnabled
+@EnableConfigurationProperties(BusProperties.class)
+public class ServiceMatcherAutoConfiguration {
+
+	@BusPathMatcher
+	// There is a @Bean of type PathMatcher coming from Spring MVC
+	@ConditionalOnMissingBean(name = BusAutoConfiguration.BUS_PATH_MATCHER_NAME)
+	@Bean(name = BusAutoConfiguration.BUS_PATH_MATCHER_NAME)
+	public PathMatcher busPathMatcher() {
+		return new DefaultBusPathMatcher(new AntPathMatcher(":"));
+	}
+
+	@Bean
+	public ServiceMatcher serviceMatcher(@BusPathMatcher PathMatcher pathMatcher,
+			BusProperties properties, Environment environment) {
+		String[] configNames = environment.getProperty(CLOUD_CONFIG_NAME_PROPERTY,
+				String[].class, new String[] {});
+		ServiceMatcher serviceMatcher = new ServiceMatcher(pathMatcher,
+				properties.getId(), configNames);
+		return serviceMatcher;
+	}
+
+}

--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/RefreshListener.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/RefreshListener.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.cloud.bus.ServiceMatcher;
 import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.context.ApplicationListener;
 
@@ -34,14 +35,25 @@ public class RefreshListener
 
 	private ContextRefresher contextRefresher;
 
-	public RefreshListener(ContextRefresher contextRefresher) {
+	private ServiceMatcher serviceMatcher;
+
+	public RefreshListener(ContextRefresher contextRefresher,
+			ServiceMatcher serviceMatcher) {
 		this.contextRefresher = contextRefresher;
+		this.serviceMatcher = serviceMatcher;
 	}
 
 	@Override
 	public void onApplicationEvent(RefreshRemoteApplicationEvent event) {
-		Set<String> keys = this.contextRefresher.refresh();
-		log.info("Received remote refresh request. Keys refreshed " + keys);
+		log.info("Received remote refresh request.");
+		if (serviceMatcher.isForSelf(event)) {
+			Set<String> keys = this.contextRefresher.refresh();
+			log.info("Keys refreshed " + keys);
+		}
+		else {
+			log.info("Refresh not performed, the event was targetting "
+					+ event.getDestinationService());
+		}
 	}
 
 }

--- a/spring-cloud-bus/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-bus/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.bus.BusPropertiesAutoConfiguration,\
+org.springframework.cloud.bus.ServiceMatcherAutoConfiguration,\
 org.springframework.cloud.bus.BusAutoConfiguration,\
 org.springframework.cloud.bus.BusRefreshAutoConfiguration,\
 org.springframework.cloud.bus.jackson.BusJacksonAutoConfiguration

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/BusAutoConfigurationClassPathTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/BusAutoConfigurationClassPathTests.java
@@ -38,6 +38,7 @@ public class BusAutoConfigurationClassPathTests {
 	public void refreshListenerCreatedWithoutActuator() {
 		new ApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(RefreshAutoConfiguration.class,
+						ServiceMatcherAutoConfiguration.class,
 						BusRefreshAutoConfiguration.class))
 				.run(context -> assertThat(context).hasSingleBean(RefreshListener.class)
 						.doesNotHaveBean(RefreshBusEndpoint.class));

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/RefreshListenerIntegrationTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/RefreshListenerIntegrationTests.java
@@ -65,6 +65,8 @@ public class RefreshListenerIntegrationTests {
 	}
 
 	@SpringBootApplication
-	static class MyApp {}
+	static class MyApp {
+
+	}
 
 }

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/RefreshListenerIntegrationTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/RefreshListenerIntegrationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.bus;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.context.refresh.ContextRefresher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Ryan Baxter
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = RefreshListenerIntegrationTests.MyApp.class,
+		properties = { "management.endpoints.web.exposure.include=*",
+				"spring.application.name=foobar" })
+public class RefreshListenerIntegrationTests {
+
+	@Autowired
+	private TestRestTemplate rest;
+
+	@Autowired
+	private ApplicationEventPublisher context;
+
+	@MockBean
+	ContextRefresher contextRefresher;
+
+	@Test
+	public void testEndpoint() {
+		System.out.println(rest.getForObject("/actuator", String.class));
+		assertThat(rest.postForEntity("/actuator/bus-refresh/demoapp", new HashMap<>(),
+				String.class).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+		assertThat(rest.postForEntity("/actuator/bus-refresh/foobar", new HashMap<>(),
+				String.class).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+		verify(contextRefresher, times(1)).refresh();
+	}
+
+	@SpringBootApplication
+	static class MyApp {}
+
+}

--- a/spring-cloud-starter-bus-amqp/pom.xml
+++ b/spring-cloud-starter-bus-amqp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-bus-amqp</artifactId>

--- a/spring-cloud-starter-bus-amqp/pom.xml
+++ b/spring-cloud-starter-bus-amqp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.1.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-bus-amqp</artifactId>

--- a/spring-cloud-starter-bus-kafka/pom.xml
+++ b/spring-cloud-starter-bus-kafka/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.1.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-bus-kafka</artifactId>

--- a/spring-cloud-starter-bus-kafka/pom.xml
+++ b/spring-cloud-starter-bus-kafka/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-bus-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-bus-kafka</artifactId>


### PR DESCRIPTION
Only refresh the context if the event received is for the given application.  Fixes #68