### PR TITLE
Fix link to github project in documentation

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -13,3 +13,5 @@
 
 :sc-ext: java
 :project-full-name: Spring Cloud Bus
+
+:docslink: https://github.com/spring-cloud/spring-cloud-bus


### PR DESCRIPTION
When visiting the documentation at https://cloud.spring.io/spring-cloud-bus/reference/html/ in the first info box the link to the project on GitHub is broken.

I hope this will fix it. I did not understand how to compile and view the build the documentation locally.