### PR TITLE
Add missing documentation links in spring-cloud-bus.adoc

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-bus.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-bus.adoc
@@ -1,5 +1,10 @@
 [[spring-cloud-bus]]
 = Spring Cloud Bus
 :page-section-summary-toc: 1
+:github: https://github.com/spring-cloud/spring-cloud-bus
+:githubmaster: {github}/tree/master
+:docslink: {githubmaster}/docs/src/main/asciidoc
+:nofooter:
+:special-string: _
 
 *{spring-cloud-version}*


### PR DESCRIPTION
<img width="955" alt="image" src="https://github.com/user-attachments/assets/9941dd01-4ddd-4dfb-b8e4-7ff4c2294d27" />