### PR TITLE
Fix custom bus event deserialization

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/jackson/BusJacksonAutoConfiguration.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/jackson/BusJacksonAutoConfiguration.java
@@ -21,9 +21,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.ConstructorDetector;
 import tools.jackson.databind.cfg.MapperBuilder;
 import tools.jackson.databind.exc.InvalidTypeIdException;
 import tools.jackson.databind.json.JsonMapper;
@@ -112,11 +114,17 @@ class BusJacksonMessageConverter extends AbstractMessageConverter implements Ini
 		super(mimeType);
 
 		if (objectMapper != null) {
-			this.mapperBuilder = objectMapper.rebuild();
+			this.mapperBuilder = objectMapper.rebuild()
+				.changeDefaultVisibility(visibility -> visibility.withCreatorVisibility(JsonAutoDetect.Visibility.NONE)
+					.withScalarConstructorVisibility(JsonAutoDetect.Visibility.NONE))
+				.constructorDetector(ConstructorDetector.EXPLICIT_ONLY);
 			this.mapperCreated = false;
 		}
 		else {
-			this.mapperBuilder = JsonMapper.builder();
+			this.mapperBuilder = JsonMapper.builder()
+				.changeDefaultVisibility(visibility -> visibility.withCreatorVisibility(JsonAutoDetect.Visibility.NONE)
+					.withScalarConstructorVisibility(JsonAutoDetect.Visibility.NONE))
+				.constructorDetector(ConstructorDetector.EXPLICIT_ONLY);
 			this.mapperCreated = true;
 		}
 	}

--- a/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/SubtypeModuleTests.java
+++ b/spring-cloud-bus/src/test/java/org/springframework/cloud/bus/jackson/SubtypeModuleTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.bus.jackson;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.junit.Test;
+import test.custom.TestEvent;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -80,6 +81,23 @@ public class SubtypeModuleTests {
 				MessageBuilder.withPayload("{\"type\":\"TestRemoteApplicationEvent\"}").build(),
 				RemoteApplicationEvent.class);
 		assertThat(event instanceof TestRemoteApplicationEvent).as("event is wrong type").isTrue();
+	}
+
+	@Test
+	public void testDeserializeCustomEventWithSimpleTypeName() throws Exception {
+		BusJacksonMessageConverter converter = new BusJacksonMessageConverter(null);
+		converter.setPackagesToScan(new String[] { "test.custom" });
+		converter.afterPropertiesSet();
+
+		Object event = converter.fromMessage(MessageBuilder
+			.withPayload("{\"type\":\"TestEvent\",\"originService\":\"publisher-service\",\"key\":\"test-key\","
+					+ "\"destinationService\":\"test-service:**\",\"id\":\"eeb09fa5-d833-460d-a132-abfec9079283\"}")
+			.build(), RemoteApplicationEvent.class);
+
+		assertThat(event).isInstanceOf(TestEvent.class);
+		assertThat(((TestEvent) event).getKey()).isEqualTo("test-key");
+		assertThat(((TestEvent) event).getOriginService()).isEqualTo("publisher-service");
+		assertThat(((TestEvent) event).getDestinationService()).isEqualTo("test-service:**");
 	}
 
 	@Test

--- a/spring-cloud-bus/src/test/java/test/custom/TestEvent.java
+++ b/spring-cloud-bus/src/test/java/test/custom/TestEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.custom;
+
+import org.springframework.cloud.bus.event.RemoteApplicationEvent;
+
+@SuppressWarnings("serial")
+public class TestEvent extends RemoteApplicationEvent {
+
+	private String key;
+
+	@SuppressWarnings("unused")
+	private TestEvent() {
+	}
+
+	public TestEvent(Object source, String originService, String destinationService, String key) {
+		super(source, originService, destinationService);
+		this.key = key;
+	}
+
+	public String getKey() {
+		return this.key;
+	}
+
+}


### PR DESCRIPTION
### What changed

This updates the Bus JSON message converter so custom `RemoteApplicationEvent` subclasses are not deserialized through implicit public constructors.

With Jackson 3, a custom event constructor such as `TestEvent(Object source, String originService, String destinationService, String key)` can be selected as a property-based creator. The incoming JSON does not contain `source`, so Jackson passes `null` and `ApplicationEvent` rejects it with `IllegalArgumentException: null source`.

The Bus event model already provides no-arg constructors for deserialization. The converter now disables implicit creator/scalar-constructor visibility for its dedicated mapper, so custom events are instantiated through the default constructor and then populated from JSON properties.

### Validation

- Reproduced the failure with a custom `TestEvent` payload matching the report in spring-cloud/spring-cloud-stream#3162.
- `./mvnw -pl spring-cloud-bus -Dtest=SubtypeModuleTests#testDeserializeCustomEventWithSimpleTypeName -Dstyle.color=never --no-transfer-progress test`
- `./mvnw -pl spring-cloud-bus -Dtest=SubtypeModuleTests,RemoteApplicationEventScanTests,BusAutoConfigurationTests -Dstyle.color=never --no-transfer-progress test`
- `./mvnw -pl spring-cloud-bus -Dstyle.color=never --no-transfer-progress test` (77 tests, 0 failures/errors)
- `git diff --check`

Addresses spring-cloud/spring-cloud-stream#3162.
