### PR TITLE
Prevent NPE in RemoteApplicationEvent constructor

### DIFF
--- a/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/RemoteApplicationEvent.java
+++ b/spring-cloud-bus/src/main/java/org/springframework/cloud/bus/event/RemoteApplicationEvent.java
@@ -59,8 +59,7 @@ public abstract class RemoteApplicationEvent extends ApplicationEvent {
 
 	protected RemoteApplicationEvent(Object source, String originService, Destination destination) {
 		super(source);
-		if (!originService.equals(TRANSIENT_ORIGIN)) {
-			Assert.notNull(originService, "originService may not be null");
+		if (!TRANSIENT_ORIGIN.equals(originService)) {
 			this.originService = originService;
 		}
 		else {


### PR DESCRIPTION
`originService` can be null and `null.equals(TRANSIENT_ORIGIN)` throws NPE